### PR TITLE
Added build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+wrench

--- a/build.go
+++ b/build.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func main_build(rootCmd *cobra.Command) {
+	var cmdBuild = &cobra.Command{
+		Use:   "build",
+		Short: "Build docker image",
+		Long:  `will build docker image for project`,
+		Run: func(cmd *cobra.Command, args []string) {
+			build()
+		},
+	}
+
+	rootCmd.AddCommand(cmdBuild)
+}
+
+func build() {
+	if fileExists("./Dockerfile.builder") {
+		fmt.Printf("INFO: %s\n", "Builder build mode")
+		buildBuilder()
+	} else if fileExists("./Dockerfile") {
+		fmt.Printf("INFO: %s\n", "Simple build mode")
+		buildSimple()
+	} else {
+		fmt.Printf("ERROR: %s\n", "No Dockerfile found.")
+		os.Exit(1)
+	}
+}
+
+func buildBuilder() {
+	image_name := fmt.Sprintf("%s/%s:%s",
+		config.Project.Organization,
+		config.Project.Name,
+		config.Project.Version)
+
+	builder_image_name := fmt.Sprintf("%s/builder-%s:%s",
+		config.Project.Organization,
+		config.Project.Name,
+		config.Project.Version)
+
+	fmt.Printf("INFO: %s %s\n\n",
+		"Found Dockerfile.builder, building image builder",
+		builder_image_name)
+
+	// Build builder image
+	cmd_string := fmt.Sprintf("docker build -f Dockerfile.builder -t '%s' .", builder_image_name)
+	cmd := exec.Command("sh", "-c", cmd_string)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nINFO: %s %s\n\n",
+		"Building image with builder",
+		image_name)
+
+	// Build image
+	cmd_string = fmt.Sprintf("docker run --rm '%s' | docker build -t '%s' -", builder_image_name, image_name)
+	cmd = exec.Command("sh", "-c", cmd_string)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Cleanup builder image
+	cmd_string = fmt.Sprintf("docker rmi '%s'", builder_image_name)
+	cmd = exec.Command("sh", "-c", cmd_string)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func buildSimple() {
+	image_name := fmt.Sprintf("%s/%s:%s",
+		config.Project.Organization,
+		config.Project.Name,
+		config.Project.Version)
+
+	fmt.Printf("INFO: %s %s\n",
+		"Found Dockerfile, building image",
+		image_name)
+
+	cmd_string := fmt.Sprintf("docker build -t '%s' .", image_name)
+	cmd := exec.Command("sh", "-c", cmd_string)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+type Project struct {
+	Organization string
+	Name         string
+	Version      string
+}
+type Config struct {
+	Project *Project
+}
+
+var config *Config
+
+func main_config(cmdRoot *cobra.Command) {
+	GenerateConfig()
+
+	var cmdConfig = &cobra.Command{
+		Use:   "config",
+		Short: "Configuration for wrench",
+		Long:  `configuration picked up by wrench and used in commands`,
+		Run: func(cmd *cobra.Command, args []string) {
+			d, err := yaml.Marshal(&config)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Printf(string(d))
+		},
+	}
+
+	cmdRoot.AddCommand(cmdConfig)
+}
+
+func GenerateConfig() {
+	var project = &Project{
+		Organization: detectProjectOrganization(),
+		Name:         detectProjectName(),
+		Version:      detectProjectVersion(),
+	}
+
+	config = &Config{
+		Project: project}
+}
+
+func detectProjectOrganization() string {
+	out, err := exec.Command("sh", "-c", "hostname -f").Output()
+	if err != nil {
+		panic(err)
+	}
+	parts := strings.Split(string(out), ".")
+
+	var org string
+	if len(parts) <= 2 {
+		// handle user.local
+		org = parts[len(parts)-1]
+	} else {
+		// handle user.organization.com
+		org = parts[len(parts)-2]
+	}
+	return strings.TrimSpace(org)
+}
+
+func detectProjectName() string {
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		panic(err)
+	}
+	return string(filepath.Base(dir))
+}
+
+func detectProjectVersion() string {
+	out, err := exec.Command("sh", "-c", "git describe").Output()
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/examples/build/builder/Dockerfile.builder
+++ b/examples/build/builder/Dockerfile.builder
@@ -1,0 +1,14 @@
+FROM golang
+
+ADD . /src
+WORKDIR "/src"
+
+# Get all package dependencies
+RUN mkdir /build
+RUN go get -t -d -v ./...
+RUN CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags=--s -o /build/hello
+RUN cp Dockerfile.runner /build/Dockerfile
+
+WORKDIR "/build"
+
+CMD tar -cf - .

--- a/examples/build/builder/Dockerfile.runner
+++ b/examples/build/builder/Dockerfile.runner
@@ -1,0 +1,5 @@
+FROM scratch
+
+ADD hello /hello
+
+ENTRYPOINT ["/hello"]

--- a/examples/build/builder/hello.go
+++ b/examples/build/builder/hello.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Printf("wrench\n")
+	fmt.Println("hello world")
 }

--- a/examples/build/simple/Dockerfile
+++ b/examples/build/simple/Dockerfile
@@ -1,0 +1,5 @@
+FROM debian
+
+ADD hello /usr/bin/
+
+ENTRYPOINT ["/usr/bin/hello"]

--- a/examples/build/simple/hello
+++ b/examples/build/simple/hello
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo hello world

--- a/main.go
+++ b/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	var rootCmd = &cobra.Command{Use: "wrench"}
+
+	main_config(rootCmd)
+	main_build(rootCmd)
+
+	rootCmd.Execute()
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"os"
+)
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return (err == nil)
+}


### PR DESCRIPTION
Builds docker images in two different ways, simple and builder mode.

Simple builds image org/app:(git describe) from Dockerfile.

Builder first builds a org/builder-app:(git describe) image from
Dockerfile.builder. The builder is expected to output tar file when run
that is used to build the actual image.