### PR TITLE
Docker requires force when reusing tags

### DIFF
--- a/push/push.go
+++ b/push/push.go
@@ -91,7 +91,7 @@ func push(registry string, additional_tags string) error {
 
 func tag_image(image_name string, new_image_name string) error {
 	command := fmt.Sprintf(
-		"docker tag %s %s",
+		"docker tag -f %s %s",
 		image_name,
 		new_image_name)
 


### PR DESCRIPTION
Force is required to tag already existing tags ex. prod, latest