### PR TITLE
Bump handle snapshot based on earlier releases

### DIFF
--- a/bats/config_detect.bats
+++ b/bats/config_detect.bats
@@ -69,7 +69,7 @@ teardown () {
     echo "ret=$ret"
     [ "$ret" -eq 0 ]
 
-    expected="Version: v0.0.0-1-g$(git rev-parse --short HEAD)"
+    expected="Version: v0.0.0-0-g$(git rev-parse --short HEAD)"
 
     echo "expected=$expected"
     echo "out=$out"

--- a/bump/bump.go
+++ b/bump/bump.go
@@ -1,8 +1,11 @@
 package bump
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/tomologic/wrench/config"
@@ -39,8 +42,6 @@ func AddToWrench(rootCmd *cobra.Command) {
 }
 
 func bump(level string) error {
-	image_name := config.GetProjectImage()
-
 	version, err := semver.Parse(config.GetProjectVersion())
 	if err != nil {
 		return err
@@ -52,34 +53,28 @@ func bump(level string) error {
 		os.Exit(0)
 	}
 
-	// Make sure docker image of current snapshot version exists
-	if !utils.DockerImageExists(image_name) {
-		fmt.Printf("ERROR: Docker image %s does not exists\n", image_name)
-		os.Exit(1)
+	// Create new release version
+	if err = version.Bump(level); err != nil {
+		return err
 	}
 
-	if err = version.Bump(level); err != nil {
-		fmt.Printf("ERROR: %s\n", err.Error())
-		os.Exit(1)
+	// Make sure docker image of current snapshot version exists
+	image_name, err := getImageName()
+	if err != nil {
+		return err
 	}
 
 	// create git tag
 	if exitcode, out := utils.RunCmd(fmt.Sprintf("git tag -a %s -m 'Release %s'", version.String(), version.String())); exitcode != 0 {
-		fmt.Printf("ERROR: git tag exited with %d: %s\n", exitcode, out)
-		os.Exit(1)
+		return errors.New(fmt.Sprintf("git tag exited with %d: %s\n", exitcode, out))
 	}
 
 	// create image
 	new_image_name := fmt.Sprintf("%s/%s:%s", config.GetProjectOrganization(), config.GetProjectName(), version.String())
-	exitcode, out := utils.RunCmd(
-		fmt.Sprintf(
-			"docker tag %s %s",
-			config.GetProjectImage(),
-			new_image_name))
+	exitcode, out := utils.RunCmd(fmt.Sprintf("docker tag %s %s", image_name, new_image_name))
 
 	if exitcode != 0 {
-		fmt.Printf("ERROR: docker tag exited with %d: %s\n", exitcode, out)
-		os.Exit(1)
+		return errors.New(fmt.Sprintf("docker tag exited with %d: %s\n", exitcode, out))
 	}
 
 	ver := strings.TrimLeft(version.String(), "v")
@@ -87,11 +82,9 @@ func bump(level string) error {
 		// remove image which is unfinished
 		utils.DockerRemoveImage(new_image_name)
 
-		fmt.Printf("ERROR: Failed updating VERSION env\n")
-		os.Exit(1)
+		return errors.New("Failed updating VERSION env")
 	}
 
-	// push tag; if err
 	if exitcode, out := utils.RunCmd(fmt.Sprintf("git push origin %s", version.String())); exitcode != 0 {
 		fmt.Printf("ERROR: git push tag exited with %d: %s\n", exitcode, out)
 		// remove image
@@ -104,10 +97,150 @@ func bump(level string) error {
 			fmt.Printf("ERROR: git tag delete exited with %d: %s\n", exitcode, out)
 		}
 
-		os.Exit(1)
+		return errors.New("Failed to push new git tag to origin")
 	}
 
 	fmt.Printf("Released %s\n", version.String())
 
 	return nil
+}
+
+func getImageName() (string, error) {
+	git_short, err := getGitShortSha()
+	if err != nil {
+		return "", err
+	}
+
+	tags, err := getGitSemverTags()
+	if err != nil {
+		return "", err
+	}
+
+	// Sort tags with semver lib
+	var versions semver.SemverList
+	for _, tag := range tags {
+		if ver, err := semver.Parse(tag); err != nil {
+			return "", err
+		} else {
+			versions = append(versions, ver)
+		}
+	}
+	sort.Sort(versions)
+
+	// Iterate over all tags
+	for _, version := range versions {
+		// Convert version back to string
+		tag := version.String()
+
+		// Calculate commit count since tag
+		num_commits, err := getGitCommitCountSince(tag)
+		if err != nil {
+			return "", err
+		}
+
+		// if count equals 0 then it's not an ancestor
+		if num_commits == 0 {
+			continue
+		}
+
+		// generate snapshot version
+		version := fmt.Sprintf("%s-%d-g%s", tag, num_commits, git_short)
+
+		// generate image name
+		image_name := fmt.Sprintf("%s/%s:%s",
+			config.GetProjectOrganization(),
+			config.GetProjectName(),
+			version)
+
+		// check if image for this snapshot version exists
+		if utils.DockerImageExists(image_name) {
+			return image_name, nil
+		}
+	}
+
+	// check if image for this snapshot version exists based on a root commit
+	roots, err := getRootCommits()
+	if err != nil {
+		return "", err
+	}
+	for _, sha := range roots {
+		// Calculate commit count since root
+		num_commits, err := getGitCommitCountSince(sha)
+		if err != nil {
+			return "", err
+		}
+
+		// generate snapshot version
+		version := fmt.Sprintf("v0.0.0-%d-g%s", num_commits, git_short)
+
+		// generate image name
+		image_name := fmt.Sprintf("%s/%s:%s",
+			config.GetProjectOrganization(),
+			config.GetProjectName(),
+			version)
+
+		// check if image for this snapshot version exists
+		if utils.DockerImageExists(image_name) {
+			return image_name, nil
+		}
+	}
+
+	// return error incase image was not found for current revision
+	return "", errors.New(fmt.Sprintf("Docker image for revision %s could not be found", git_short))
+}
+
+func getGitSemverTags() ([]string, error) {
+	exitcode, out := utils.RunCmd("git tag -l 'v[0-9]*\\.[0-9]*\\.[0-9]*'")
+	if exitcode != 0 {
+		return nil, errors.New(fmt.Sprintf("%s: %s", exitcode, out))
+	}
+
+	// Split lines into slice
+	tags := strings.Split(out, "\n")
+
+	// Remove empty rows
+	tags = utils.RemoveEmptyStrings(tags)
+
+	return tags, nil
+}
+
+func getRootCommits() ([]string, error) {
+	exitcode, out := utils.RunCmd("git rev-list --max-parents=0 HEAD")
+	if exitcode != 0 {
+		return nil, errors.New(fmt.Sprintf("%s: %s", exitcode, out))
+	}
+
+	// Split lines into slice
+	roots := strings.Split(out, "\n")
+
+	// Remove empty rows
+	roots = utils.RemoveEmptyStrings(roots)
+
+	return roots, nil
+}
+
+func getGitCommitCountSince(sha string) (int, error) {
+	exitcode, out := utils.RunCmd(fmt.Sprintf("git rev-list %s..HEAD --count", sha))
+	if exitcode != 0 {
+		return 0, errors.New(out)
+	}
+
+	num, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, err
+	}
+
+	return num, nil
+}
+
+func getGitShortSha() (string, error) {
+	exitcode, out := utils.RunCmd("git rev-parse --short HEAD")
+	if exitcode == 128 {
+		return "", errors.New("No semver formatted git tag found")
+	} else if exitcode != 0 {
+		return "", errors.New(out)
+	} else if out == "" {
+		return "", errors.New("Empty output from git rev-parse")
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -398,6 +398,9 @@ var getGitCommitCount = func() (int, error) {
 		return 0, err
 	}
 
+	// Get number of commits since initial commit instead of total
+	num -= 1
+
 	return num, nil
 }
 
@@ -416,6 +419,7 @@ var getGitShortSha = func() (string, error) {
 var generateInitialVersion = func() string {
 	// Get number of commits
 	num_commits, err := getGitCommitCount()
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/config/git_test.go
+++ b/config/git_test.go
@@ -23,7 +23,8 @@ func (suite *GitTestSuite) TearDownTest() {
 func (suite *GitTestSuite) TestGitCommitCount() {
 	for _, i := range []int{0, 1, 5, 10, 50, 99, 100, 1000, 10000} {
 		runCmd = func(string) (int, string) {
-			return 0, fmt.Sprintf("%d", i)
+			// return +1 since git cli returns total number of commits
+			return 0, fmt.Sprintf("%d", (i + 1))
 		}
 
 		num_commits, err := getGitCommitCount()

--- a/examples/simple/wrench.yml
+++ b/examples/simple/wrench.yml
@@ -6,3 +6,7 @@ Run:
     #!/bin/bash -xe
 
     echo "run syntax check"
+  echo-version: |
+    #!/bin/bash -xe
+
+    echo $VERSION

--- a/push/push.go
+++ b/push/push.go
@@ -37,20 +37,10 @@ func AddToWrench(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(cmdBump)
 }
 
-func remove_empty_strings(s []string) []string {
-	var r []string
-	for _, str := range s {
-		if str != "" {
-			r = append(r, str)
-		}
-	}
-	return r
-}
-
 func push(registry string, additional_tags string) error {
 	tags := strings.Split(additional_tags, ",")
 	tags = append(tags, config.GetProjectVersion())
-	tags = remove_empty_strings(tags)
+	tags = utils.RemoveEmptyStrings(tags)
 
 	for _, tag := range tags {
 		image_name := fmt.Sprintf("%s/%s:%s",

--- a/semver/semver.go
+++ b/semver/semver.go
@@ -14,6 +14,8 @@ type Semver struct {
 	Snapshot string
 }
 
+type SemverList []Semver
+
 func Parse(s string) (Semver, error) {
 	sv := Semver{}
 
@@ -94,6 +96,29 @@ func (s Semver) String() string {
 func (s Semver) IsReleaseVersion() bool {
 	if s.Snapshot == "" {
 		return true
+	}
+	return false
+}
+
+func (s SemverList) Len() int {
+	return len(s)
+}
+
+func (s SemverList) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s SemverList) Less(i, j int) bool {
+	if s[i].Major < s[j].Major {
+		return true
+	} else if s[i].Major == s[j].Major {
+		if s[i].Minor < s[j].Minor {
+			return true
+		} else if s[i].Minor == s[j].Minor {
+			if s[i].Patch < s[j].Patch {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -1,6 +1,7 @@
 package semver
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -201,5 +202,39 @@ func (suite *SemverTestSuite) TestSemverIsReleaseVersion() {
 		actual := ex.Input.IsReleaseVersion()
 
 		assert.Equal(suite.T(), ex.Expected, actual)
+	}
+}
+
+func (suite *SemverTestSuite) TestSemverSort() {
+	var unsorted = []Semver{
+		Semver{3, 3, 3, ""},
+		Semver{0, 3, 0, ""},
+		Semver{1, 1, 0, ""},
+		Semver{0, 1, 0, ""},
+		Semver{0, 2, 0, ""},
+		Semver{0, 0, 0, ""},
+		Semver{3, 3, 0, ""},
+		Semver{2, 2, 0, ""},
+		Semver{3, 3, 1, ""},
+		Semver{3, 3, 2, ""},
+	}
+
+	var sorted = []Semver{
+		Semver{0, 0, 0, ""},
+		Semver{0, 1, 0, ""},
+		Semver{0, 2, 0, ""},
+		Semver{0, 3, 0, ""},
+		Semver{1, 1, 0, ""},
+		Semver{2, 2, 0, ""},
+		Semver{3, 3, 0, ""},
+		Semver{3, 3, 1, ""},
+		Semver{3, 3, 2, ""},
+		Semver{3, 3, 3, ""},
+	}
+
+	sort.Sort(SemverList(unsorted))
+
+	for index, _ := range sorted {
+		assert.Equal(suite.T(), sorted[index], unsorted[index])
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -137,3 +137,13 @@ func CreateTar(files []Tarfile) (*bytes.Buffer, error) {
 
 	return buf, nil
 }
+
+func RemoveEmptyStrings(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}


### PR DESCRIPTION
Currently wrench will presume the snapshot image name from latest tag.

But incase a snapshot was built upon a snapshot version then the image created will have a different name.

Make wrench look deeper for the snapshot image.

```
v0.221.0-1-g20bdef5 # Currently the only one considered
v0.220.0-2-g20bdef5
v0.219.0-3-g20bdef5
...
v0.190.0-X-g20bdef5
```