### PR TITLE
Add packaging to deb and rpm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ install: |
   pushd bats_install
   sudo bash install.sh /usr/local
   popd
+
+  # Install utils for packaging
+  gem install fpm --no-ri --no-rdoc
+  sudo apt-get update -qq
+  sudo apt-get install -qq -y rpm
 before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888
   sudo iptables -L DOCKER || sudo iptables -N DOCKER
@@ -44,11 +49,12 @@ before_deploy: |
 
   # Build
   make build
+  make package
 deploy:
   provider: releases
   api_key:
     secure: QA/8DQ3ClZgQEu4sAAai3BwdB3xecyXzs+vriKNPaSB7hn75UkEndLy4vP7891qxEYm5sfiqshObnCt3VGD1Z9F/ZNRFsPJatk4dw9zH0jMebiDZCBKHZ1jEgQZDN14CdkMhcGtTAEr85QwpTtk6Verfvxy9XYTUdPe59T9vfM9tERLvDYyDXA5ps4l0rCJYBtJ5H/oy7lVKgMj32kEqVrOQKBD+93NjhsM7KXMaH8HRXpCh1Zvd1N9H/k7k6Q+XFbDmw9rd5WFt3+46J41El+/NH95S144GT+WUopz7pdwu5DWH2d9Jsf8sfRjJFMXV37TenEmtAp9R8TGXiqLkzHcRDr9HQAH4gi+51srxpbfoPpyJSXuflWopPO48Jia3+Boh6g9K/3qyRkqAliYKPqazECrs2nhmNTh4/CCEWXbX50h7Z8hgEXrGrYtah1HHyvrSgjEBL9NsLNdFMtMkWdkas4xZL8oEO5to3doSgckKkNFR+jiwNBPZ+eLOGohURwNdl8xfrxV9jssqBehch4xAoEqgVbGwS5z7XoCI8Vcte8HpkyfRNEKdTn1KF1ZzfwSc6PbY3hHg+9Tj6N+kE4ETHMOhhAIk2lsYP26eaax6XpfPbfUpwTfQAE/J+mdnJVxPzhZ6N9O+4Xhdm6zWch6qR41kY4+Vf5+grX1GoPM=
-  file: wrench-*
+  file: ARTIFACTS/*
   file_glob: true
   skip_cleanup: true
   on:

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,57 @@
-.PHONY: build build_darwin build_linux
-
 GO_VERSION = 1.4
 BINARY_NAME = wrench
-VERSION = $(shell git describe)
+BUILDDIR = ./ARTIFACTS
 
-# Travis CI Gimme is used to cross-compile wrench
-# https://github.com/travis-ci/gimme
+# Remove prefix since deb, rpm etc don't recognize this as valid version
+VERSION = $(shell git describe | sed 's/^v//')
+
+# EXPLICITLY removing artifacts directory to protect from horrible accidents
+clean:
+	rm -rf ./ARTIFACTS
+
+###############################################################################
+## Building
+##
+## Travis CI Gimme is used to cross-compile wrench
+## https://github.com/travis-ci/gimme
+###############################################################################
+
+.PHONY: build build_darwin build_linux
+build: build_darwin build_linux
+
 compile = bash -c "eval \"$$(GIMME_GO_VERSION=$(GO_VERSION) GIMME_OS=$(1) GIMME_ARCH=$(2) gimme)\"; \
 					go build -a \
 						-ldflags \"-w -X main.VERSION '$(VERSION)'\" \
-						-o $(BINARY_NAME)-$(VERSION)-$(1)-$(2)"
-
-build: build_darwin build_linux
+						-o $(BUILDDIR)/$(BINARY_NAME)-$(VERSION)-$(1)-$(2)"
 
 build_darwin:
 	$(call compile,darwin,amd64)
 
 build_linux:
 	$(call compile,linux,amd64)
+
+
+###############################################################################
+## Packaging
+##
+## Effing Package Management - fpm is used for packaging
+## https://github.com/jordansissel/fpm
+## gnu-tar, rpmbuild is required
+###############################################################################
+
+.PHONY: package package_deb package_rpm
+package: package_deb package_rpm
+
+package = fpm -t $(1) \
+			-n wrench \
+			--force \
+			--version $(VERSION) \
+			--rpm-os linux \
+			--package $(BUILDDIR) \
+			-s dir $(BUILDDIR)/wrench-$(VERSION)-linux-amd64=/usr/local/bin/wrench
+
+package_deb:
+	$(call package,deb)
+
+package_rpm:
+	$(call package,rpm)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,36 @@ brew tap tomologic/homebrew-tap
 brew install wrench
 ```
 
+## Build
+
+[Travis CI Gimme](https://github.com/travis-ci/gimme) is used to cross-compile wrench.
+
+```
+$ brew install gimme
+```
+
+```
+$ make build
+$ make build_darwin
+$ make build_linux
+```
+
+## Package
+
+[Effing Package Management - fpm](https://github.com/jordansissel/fpm) is used for packaging.
+
+```
+$ brew install gnu-tar
+$ brew install rpm
+$ gem install fpm
+```
+
+```
+$ make package
+$ make package_deb
+$ make package_rpm
+```
+
 ## Project config
 
 ### Print wrench config


### PR DESCRIPTION
Utilize fpm to package wrench linux binary to debian and rhel packages.
Move all built artifacts to separate directory to make it easier to
clean directory and for travis to send all artifacts to github releases.