### PR TITLE
Deprecate force flag for docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Travis](https://img.shields.io/travis/tomologic/wrench.svg?style=flat-square)](https://travis-ci.org/tomologic/wrench)
 
+Compatible Docker releases: 1.10.0 - 1.12.0
+
 ## What is this?
 
 This is our current try to create standards for building, testing and deploying our applications.
@@ -258,8 +260,8 @@ Following blocks are equivalent:
 ```
 # Prepare tags for pushing (force required for existing tags)
 docker tag example/foobar:$(git describe) registry.local:5000/example/foobar:$(git describe)
-docker tag -f example/foobar:$(git describe) registry.local:5000/example/foobar:latest
-docker tag -f example/foobar:$(git describe) registry.local:5000/example/foobar:prod
+docker tag example/foobar:$(git describe) registry.local:5000/example/foobar:latest
+docker tag example/foobar:$(git describe) registry.local:5000/example/foobar:prod
 
 # Push both tags
 docker push registry.local:5000/example/foobar:$(git describe)

--- a/push/push.go
+++ b/push/push.go
@@ -81,7 +81,7 @@ func push(registry string, additional_tags string) error {
 
 func tag_image(image_name string, new_image_name string) error {
 	command := fmt.Sprintf(
-		"docker tag -f %s %s",
+		"docker tag %s %s",
 		image_name,
 		new_image_name)
 


### PR DESCRIPTION
-f flag on docker tag
Deprecated In Release: v1.10.0
Removed In Release: v1.12.0

Source: https://docs.docker.com/engine/deprecated/

@tomologic/owners 