### PR TITLE
Do not use gimme during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GO_VERSION = 1.8
 NAME = wrench
 BUILDDIR = ./ARTIFACTS
 
@@ -7,16 +6,12 @@ VERSION = $(shell git describe --tags --match 'v[0-9]*\.[0-9]*\.[0-9]*' | sed 's
 
 ###############################################################################
 ## Building
-##
-## Travis CI Gimme is used to cross-compile
-## https://github.com/travis-ci/gimme
 ###############################################################################
 
 .PHONY: build build_darwin build_linux
 build: build_darwin build_linux
 
-compile = bash -c "eval \"$$(GIMME_GO_VERSION=$(GO_VERSION) GIMME_OS=$(1) GIMME_ARCH=$(2) gimme)\"; \
-					go build -a \
+compile = bash -c "env GOOS=$(1) GOARCH=$(2) go build -a \
 						-ldflags \"-w -X main.VERSION='$(VERSION)'\" \
 						-o $(BUILDDIR)/$(NAME)-$(VERSION)-$(1)-$(2)"
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ brew install wrench
 
 ## Build
 
-[Travis CI Gimme](https://github.com/travis-ci/gimme) is used to cross-compile wrench.
-
-```
-$ brew install gimme
-```
-
 ```
 $ make build
 $ make build_darwin


### PR DESCRIPTION
Gimme has broken cross-compilation:
https://github.com/travis-ci/gimme/issues/42

Anyway golang now has cross-compilation built-in so we can just use go
build with GOOS and GOARCH environment variables.

Fixes issue where Travis released a linux binary as a darwin binary for
wrench 0.41.0